### PR TITLE
blend: reverse logic

### DIFF
--- a/dreamer.py
+++ b/dreamer.py
@@ -285,7 +285,7 @@ def main(inputdir, outputdir, preview, octaves, octave_scale, iterations, jitter
                         newimg = resizePicture(newframe, preview)
                     frame = newimg
                 else:
-                    frame = morphPicture(saveframe, newframe, blend, preview)
+                    frame = morphPicture(newframe, saveframe, blend, preview)
 
                 # setup next frame
                 frame = np.float32(frame)


### PR DESCRIPTION
The blend logic seemed inconsistent - 0 meant "none of the previous
frame gets through", but then surprisingly 0.01 meant "almost all of
the previous frame gets through".

This commit reverses the blend so that there is a continuum from 0 to 1.
